### PR TITLE
fix: fall back to signer when rpcConfig lacks target chain in resolver

### DIFF
--- a/core/class/GAP.ts
+++ b/core/class/GAP.ts
@@ -12,6 +12,7 @@ import {
   GAPRpcConfig,
   SchemaInterface,
   SignerOrProvider,
+  SupportedChainId,
   TNetwork,
   TSchemaName,
 } from "../types";
@@ -432,17 +433,18 @@ export class GAP extends Facade {
           (await signer.getChainId())
       );
 
-    if (chainId && !rpcConfig) {
-      throw new Error(
-        `rpcConfig is required when specifying chainId for cross-chain operations. ` +
-        `Either provide rpcConfig or omit chainId to use the signer's chain.`
-      );
-    }
-
-    const provider =
+    // Use rpcConfig provider if available for the target chain,
+    // otherwise fall back to signer (which may already be a provider
+    // for the correct chain, e.g. when created by the frontend).
+    const rpcUrl =
       chainId && rpcConfig
-        ? getWeb3Provider(chainId, rpcConfig)
-        : signer;
+        ? rpcConfig[chainId as SupportedChainId]
+        : undefined;
+
+    const provider = rpcUrl
+      ? getWeb3Provider(chainId!, rpcConfig!)
+      : signer;
+
     const network = Object.values(Networks).find(
       (n) => +n.chainId === Number(currentChainId)
     );
@@ -474,17 +476,18 @@ export class GAP extends Facade {
           (await signer.getChainId())
       );
 
-    if (chainId && !rpcConfig) {
-      throw new Error(
-        `rpcConfig is required when specifying chainId for cross-chain operations. ` +
-        `Either provide rpcConfig or omit chainId to use the signer's chain.`
-      );
-    }
-
-    const provider =
+    // Use rpcConfig provider if available for the target chain,
+    // otherwise fall back to signer (which may already be a provider
+    // for the correct chain, e.g. when created by the frontend).
+    const rpcUrl =
       chainId && rpcConfig
-        ? getWeb3Provider(chainId, rpcConfig)
-        : signer;
+        ? rpcConfig[chainId as SupportedChainId]
+        : undefined;
+
+    const provider = rpcUrl
+      ? getWeb3Provider(chainId!, rpcConfig!)
+      : signer;
+
     const network = Object.values(Networks).find(
       (n) => +n.chainId === Number(currentChainId)
     );


### PR DESCRIPTION
## Summary
- `GAP.getProjectResolver` and `getCommunityResolver` now check if `rpcConfig` actually has an RPC URL for the target chain before using it
- Falls back to the signer (already a provider for the correct chain) instead of throwing

### Root cause
`AllGapSchemas.findSchema` creates GAP instances via `GAP.getInstance({ network })` without `rpcUrls`, resulting in `rpcConfig = {}`. Since `{}` is truthy, `getProjectResolver` called `getWeb3Provider(chainId, {})` which threw "RPC URL not configured for chain X". This error was caught upstream, causing `isOwner` to silently return `false` for cross-chain projects.

### Changes
- `core/class/GAP.ts`: both `getProjectResolver` and `getCommunityResolver` now check `rpcConfig[chainId]` before attempting `getWeb3Provider`, falling back to the signer parameter

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Verify ownership check works for projects on non-default chains
- [ ] Verify ownership check still works for same-chain projects with full rpcConfig