### PR TITLE
feat: add type parameter to slugExists and generateSlug

### DIFF
--- a/core/class/Fetcher.ts
+++ b/core/class/Fetcher.ts
@@ -213,7 +213,10 @@ export abstract class Fetcher extends AxiosGQL {
    * @param slug
    * @returns
    */
-  abstract slugExists(slug: string): Promise<boolean>;
+  abstract slugExists(
+    slug: string,
+    type?: "project" | "community"
+  ): Promise<boolean>;
 
   /**
    * Get grants for a project by an external uid

--- a/core/class/GAP.ts
+++ b/core/class/GAP.ts
@@ -333,7 +333,10 @@ export class GAP extends Facade {
    * @param text
    * @returns
    */
-  generateSlug = async (text: string): Promise<string> => {
+  generateSlug = async (
+    text: string,
+    type?: "project" | "community"
+  ): Promise<string> => {
     let slug = text
       .toLowerCase()
       // Remove emojis
@@ -354,7 +357,7 @@ export class GAP extends Facade {
     ): Promise<string> => {
       const slugToCheck =
         counter === 0 ? currentSlug : `${currentSlug}-${counter}`;
-      const slugExists = await this.fetch.slugExists(slugToCheck);
+      const slugExists = await this.fetch.slugExists(slugToCheck, type);
 
       if (slugExists) {
         return checkSlug(currentSlug, counter + 1);

--- a/core/class/GraphQL/GapEasClient.ts
+++ b/core/class/GraphQL/GapEasClient.ts
@@ -427,7 +427,7 @@ export class GapEasClient extends Fetcher {
     return withDetails;
   }
 
-  async slugExists(slug: string) {
+  async slugExists(slug: string, _type?: "project" | "community") {
     const details = this.gap.findSchema("ProjectDetails");
 
     const query = gqlQueries.attestationsOf(details.uid, "slug");

--- a/core/class/karma-indexer/GapIndexerClient.ts
+++ b/core/class/karma-indexer/GapIndexerClient.ts
@@ -256,8 +256,11 @@ export class GapIndexerClient extends Fetcher {
     throw new Error("Method not implemented.");
   }
 
-  async slugExists(slug: string): Promise<boolean> {
-    return await this.apiClient.slugExists(slug);
+  async slugExists(
+    slug: string,
+    type?: "project" | "community"
+  ): Promise<boolean> {
+    return await this.apiClient.slugExists(slug, type);
   }
 
   /**

--- a/core/class/karma-indexer/api/GapIndexerApi.ts
+++ b/core/class/karma-indexer/api/GapIndexerApi.ts
@@ -22,6 +22,8 @@ const Endpoints = {
     all: () => "/communities",
     admins: (uid: string) => `/communities/${uid}/admins`,
     byUidOrSlug: (uidOrSlug: string) => `/communities/${uidOrSlug}`,
+    checkSlugAvailability: (slug: string) =>
+      `/v2/communities/slug/check/${slug}`,
     grants: (uidOrSlug: string, page: number = 0, pageLimit: number = 100) =>
       `/communities/${uidOrSlug}/grants?${page ? `page=${page}` : ""}${
         pageLimit ? `&pageLimit=${pageLimit}` : ""
@@ -318,10 +320,15 @@ export class GapIndexerApi extends AxiosGQL {
     return response;
   }
 
-  async slugExists(slug: string): Promise<boolean> {
-    const { data } = await this.client.get<{ available: boolean }>(
-      Endpoints.project.checkSlugAvailability(slug)
-    );
+  async slugExists(
+    slug: string,
+    type?: "project" | "community"
+  ): Promise<boolean> {
+    const endpoint =
+      type === "community"
+        ? Endpoints.communities.checkSlugAvailability(slug)
+        : Endpoints.project.checkSlugAvailability(slug);
+    const { data } = await this.client.get<{ available: boolean }>(endpoint);
     return !data.available;
   }
 


### PR DESCRIPTION
## Summary
- Add optional `type` parameter (`'project' | 'community'`) to `slugExists()` and `generateSlug()` across all fetcher implementations
- Default behavior unchanged (checks projects) for backward compatibility
- When `type='community'`, routes to new `/v2/communities/slug/check/:slug` endpoint

## Changed files
- `GapIndexerApi.ts` — add community endpoint + type-aware `slugExists()`
- `Fetcher.ts` — update abstract signature
- `GapIndexerClient.ts` — pass type through to apiClient
- `GapEasClient.ts` — accept param (ignored, GraphQL only has projects)
- `GAP.ts` — `generateSlug()` passes type to `slugExists()`

## Context
Part of a cross-repo change to allow projects and communities to share the same slug:
- **gap-indexer**: [feat/community-slug-check](https://github.com/show-karma/gap-indexer/tree/feat/community-slug-check) — new community slug check endpoint
- **gap-app-v2**: [feat/community-slug-check](https://github.com/show-karma/gap-app-v2/tree/feat/community-slug-check) — passes `type='community'` in CommunityDialog

## Test plan
- [ ] `yarn build` passes with zero errors
- [ ] `slugExists('test')` without type still checks projects (backward compat)
- [ ] `slugExists('test', 'community')` routes to community endpoint
- [ ] `generateSlug('test', 'community')` generates community-scoped slugs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Improvements**
  * Slug validation system now supports type-specific availability checks, enabling independent verification of slug uniqueness for projects and communities. This prevents slug collisions within specific resource categories and improves overall data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->