### PR TITLE
fix: pin axios to 1.14.0 — supply chain attack mitigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@ethereum-attestation-service/eas-sdk": "1.4.2",
     "@gelatonetwork/relay-sdk": "^5.6.0",
     "@types/sha256": "^0.2.0",
-    "axios": "^1.7.9",
+    "axios": "1.14.0",
     "dotenv": "^17.2.3",
     "ethers": "6.11.0",
     "sha256": "^0.2.0",
@@ -36,7 +36,8 @@
   },
   "overrides": {
     "ws": ">=8.17.1",
-    "cookie": ">=0.7.0"
+    "cookie": ">=0.7.0",
+    "axios": "1.14.0"
   },
   "devDependencies": {
     "@types/node": "^20.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.2.0
         version: 0.2.2
       axios:
-        specifier: ^1.7.9
-        version: 1.11.0
+        specifier: 1.14.0
+        version: 1.14.0
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -602,8 +602,8 @@ packages:
   axios@0.29.0:
     resolution: {integrity: sha512-Kjsq1xisgO5DjjNQwZFsy0gpcU1P2j36dZeQDXVhpIU26GVgkDUnROaHLSuluhMqtDE7aKA2hbKXG5yu5DN8Tg==}
 
-  axios@1.11.0:
-    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
+  axios@1.14.0:
+    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1052,6 +1052,10 @@ packages:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   fp-ts@1.19.3:
     resolution: {integrity: sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==}
 
@@ -1102,7 +1106,7 @@ packages:
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
@@ -1617,6 +1621,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2925,11 +2933,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.11.0:
+  axios@1.14.0:
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.1)
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -3499,6 +3507,14 @@ snapshots:
       is-callable: 1.2.7
 
   form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -4139,6 +4155,8 @@ snapshots:
   prettier@3.6.2: {}
 
   proxy-from-env@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
## Summary

- **Security**: Pins axios to `1.14.0` (last safe version) to prevent resolution to compromised `1.14.1`/`0.30.4`
- Adds `overrides` entry to enforce the pin across all transitive dependencies
- Lock file updated to reflect pinned version

## Context

On March 30, 2026, axios versions `1.14.1` and `0.30.4` were published with a malicious dependency (`plain-crypto-js@4.2.1`) containing a trojan with C2 callback. The axios maintainers have lost control of the npm package — the attacker's permissions exceed theirs.

**Our caret range (`^1.7.9`) could resolve to the compromised version on any fresh install.**

Reference: https://socket.dev/blog/axios-npm-package-compromised

## Test plan

- [x] Verified no compromised versions in lock file
- [x] Verified no `plain-crypto-js` in dependency tree
- [x] `pnpm install` resolves to `1.14.0`
- [ ] CI passes with pinned version