### PR TITLE
feat: add cancelled milestone status (DEV-523)

### DIFF
--- a/core/class/entities/Milestone.ts
+++ b/core/class/entities/Milestone.ts
@@ -49,6 +49,7 @@ export class Milestone extends Attestation<IMilestone> implements IMilestone {
   completed: MilestoneCompleted;
   approved: MilestoneCompleted;
   rejected: MilestoneCompleted;
+  cancelled: MilestoneCompleted;
   verified: MilestoneCompleted[] = [];
   type = "milestone";
   priority?: number;
@@ -306,6 +307,58 @@ export class Milestone extends Attestation<IMilestone> implements IMilestone {
       {
         schemaId: this.completed.schema.uid,
         uid: this.completed.uid,
+      },
+    ]);
+    return { tx, uids };
+  }
+
+  /**
+   * Cancels this milestone. A cancelled milestone will not be delivered and is
+   * kept, badged "cancelled", for the program's records. Only milestones that
+   * are not yet completed or verified can be cancelled.
+   * @param signer
+   * @param reason
+   */
+  async cancel(signer: SignerOrProvider, reason = "", callback?: Function) {
+    if (this.completed || this.verified?.length)
+      throw new AttestationError(
+        "ATTEST_ERROR",
+        "Cannot cancel a completed or verified milestone"
+      );
+
+    const schema = this.schema.gap.findSchema("MilestoneCompleted");
+    if (this.schema.isJsonSchema()) {
+      schema.setValue("json", JSON.stringify({ type: "cancelled", reason }));
+    } else {
+      schema.setValue("type", "cancelled");
+      schema.setValue("reason", reason);
+    }
+    await this.attestStatus(signer, schema, callback);
+
+    this.cancelled = new MilestoneCompleted({
+      data: {
+        type: "cancelled",
+        reason,
+      },
+      refUID: this.uid,
+      schema: schema,
+      recipient: this.recipient,
+    });
+  }
+
+  /**
+   * Revokes the cancelled status of the milestone (un-cancel). If the milestone
+   * is not cancelled, it will throw an error.
+   * @param signer
+   */
+  async revokeCancel(signer: SignerOrProvider) {
+    if (!this.cancelled)
+      throw new AttestationError("ATTEST_ERROR", "Milestone is not cancelled");
+
+    const { tx, uids } = await this.cancelled.schema.multiRevoke(signer, [
+      {
+        schemaId: this.cancelled.schema.uid,
+        uid: this.cancelled.uid,
       },
     ]);
     return { tx, uids };

--- a/core/class/entities/Milestone.ts
+++ b/core/class/entities/Milestone.ts
@@ -333,7 +333,7 @@ export class Milestone extends Attestation<IMilestone> implements IMilestone {
       schema.setValue("type", "cancelled");
       schema.setValue("reason", reason);
     }
-    await this.attestStatus(signer, schema, callback);
+    const { uids } = await this.attestStatus(signer, schema, callback);
 
     this.cancelled = new MilestoneCompleted({
       data: {
@@ -341,6 +341,7 @@ export class Milestone extends Attestation<IMilestone> implements IMilestone {
         reason,
       },
       refUID: this.uid,
+      uid: uids?.[0],
       schema: schema,
       recipient: this.recipient,
     });
@@ -864,6 +865,20 @@ export class Milestone extends Attestation<IMilestone> implements IMilestone {
           ...attestation.rejected,
           data: {
             ...attestation.completed.data,
+          },
+          schema: new AllGapSchemas().findSchema(
+            "MilestoneCompleted",
+            chainIdToNetwork[attestation.chainID] as TNetwork
+          ),
+          chainID: attestation.chainID,
+        });
+      }
+
+      if (attestation.cancelled) {
+        milestone.cancelled = new MilestoneCompleted({
+          ...attestation.cancelled,
+          data: {
+            ...attestation.cancelled.data,
           },
           schema: new AllGapSchemas().findSchema(
             "MilestoneCompleted",

--- a/core/class/entities/Milestone.ts
+++ b/core/class/entities/Milestone.ts
@@ -326,6 +326,12 @@ export class Milestone extends Attestation<IMilestone> implements IMilestone {
         "Cannot cancel a completed or verified milestone"
       );
 
+    if (this.cancelled)
+      throw new AttestationError(
+        "ATTEST_ERROR",
+        "Milestone is already cancelled"
+      );
+
     const schema = this.schema.gap.findSchema("MilestoneCompleted");
     if (this.schema.isJsonSchema()) {
       schema.setValue("json", JSON.stringify({ type: "cancelled", reason }));

--- a/core/class/entities/Milestone.ts
+++ b/core/class/entities/Milestone.ts
@@ -65,7 +65,7 @@ export class Milestone extends Attestation<IMilestone> implements IMilestone {
     newData: Partial<IMilestone>,
     callback?: Function
   ): Promise<AttestationWithTx> {
-    if (this.completed || this.approved || this.verified?.length) {
+    if (this.completed || this.approved || this.verified?.length || this.cancelled) {
       throw new AttestationError(
         "ATTEST_ERROR",
         "Cannot edit milestone that is not in PENDING state"

--- a/core/class/karma-indexer/api/types.ts
+++ b/core/class/karma-indexer/api/types.ts
@@ -52,6 +52,7 @@ export interface IMilestoneResponse extends IAttestationResponse {
   completed?: IMilestoneCompleted;
   approved?: IMilestoneCompleted;
   rejected?: IMilestoneCompleted;
+  cancelled?: IMilestoneCompleted;
   verified?: IMilestoneCompleted[];
   data: {
     title: string;

--- a/core/class/types/attestations.ts
+++ b/core/class/types/attestations.ts
@@ -114,7 +114,7 @@ export class MemberDetails
 }
 
 export interface IMilestoneCompleted {
-  type?: "approved" | "rejected" | "completed" | "verified";
+  type?: "approved" | "rejected" | "completed" | "verified" | "cancelled";
   reason?: string;
   proofOfWork?: string;
 }
@@ -122,7 +122,7 @@ export class MilestoneCompleted
   extends Attestation<IMilestoneCompleted>
   implements IMilestoneCompleted
 {
-  type: "approved" | "rejected" | "completed" | "verified";
+  type: "approved" | "rejected" | "completed" | "verified" | "cancelled";
   reason?: string;
   proofOfWork?: string;
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "Simple and easy interface between EAS and Karma.",
   "main": "./index.js",
   "author": "KarmaHQ",


### PR DESCRIPTION
## Overview

Adds a **cancelled** milestone status so programs can cancel a milestone (keep it on the record, badged Cancelled) instead of deleting it. Part of DEV-523; consumed by gap-indexer and gap-app-v2.

## Changes

- `IMilestoneCompleted.type` union gains `"cancelled"` — a new value of the existing on-chain status field (`string type, string reason`), so **no new EAS schema**.
- `Milestone.cancel(signer, reason?)` / `Milestone.revokeCancel(signer)` (mirroring `reject`/`revokeRejection`), plus a `cancelled` field. `cancel()` guards against completed/verified milestones.
- `Milestone.from` decodes a fetched cancellation into `milestone.cancelled` (new `IMilestoneResponse.cancelled`), and `cancel()` captures the attestation uid, so un-cancel works end-to-end.
- Version bump 0.4.27 → **0.4.28** (must publish before the indexer/FE PRs can consume it).

## Testing

- `yarn build` passes.

## Rollout

Publish 0.4.28 to npm first; the gap-indexer and gap-app-v2 PRs pin this version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **cancelled** milestone state, including support for cancelling with an optional reason.
  * Added the ability to revoke a previously submitted cancellation.
  * Updated milestone details to display and recognize the cancelled status.

* **Updates**
  * Expanded milestone completed attestation types to include **cancelled**, and updated indexer responses accordingly.
  * Prevent editing of milestones once they are marked cancelled.
  * Bumped package version to **0.4.28**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->