### PR TITLE
chore: update example scripts and readme to karmahq.org (DEV-622)

### DIFF
--- a/core/scripts/create-program.ts
+++ b/core/scripts/create-program.ts
@@ -23,10 +23,10 @@ export async function main() {
   const metadata = {
     title: name,
     description: `Karma Gap Registry`,
-    website: "www.karmahq.xyz",
+    website: "www.karmahq.org",
     projectTwitter: "karmahq_",
-    logoImg: "www.karmahq.xyz/logo/karma-gap-logo.svg",
-    bannerImg: "www.karmahq.xyz/logo/karma-gap-logo.svg",
+    logoImg: "www.karmahq.org/logo/karma-gap-logo.svg",
+    bannerImg: "www.karmahq.org/logo/karma-gap-logo.svg",
     logoImgData: {},
     bannerImgData: {},
     credentials: {},

--- a/create-community-example.ts
+++ b/create-community-example.ts
@@ -83,7 +83,7 @@ async function main() {
     }
     console.log(`Transaction Hash: ${result.tx[0].hash}`);
     console.log(
-      `\nYou can view your community at: https://www.karmahq.xyz/community/${communityDetails.slug}`
+      `\nYou can view your community at: https://www.karmahq.org/community/${communityDetails.slug}`
     );
 
     // Fetch the created community to verify

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@
 
 ## 1. What is Karma SDK?
 
-The Karma SDK is a library for easy integration with [Karma](https://www.karmahq.xyz). Using this library, you will be able to:
+The Karma SDK is a library for easy integration with [Karma](https://www.karmahq.org). Using this library, you will be able to:
 
 - Fetch and display Communities, Projects, Members, Grants, Milestones, and all of their dependencies.
 - Create, update and delete all of the above.


### PR DESCRIPTION
SDK half of the `karmahq.xyz` → `karmahq.org` migration ([DEV-617](https://linear.app/showkarma/issue/DEV-617) / DEV-622).

Smallest of the three PRs. **No domain module is introduced here** — library code (`core/class/`, `core/consts.ts`) contains zero karmahq hosts. Only demo and deploy scripts and the readme reference the domain.

## Changed

- `core/scripts/create-program.ts` — `website` / `logoImg` / `bannerImg`. These are written into EAS attestation payloads, so **new attestations will carry `.org` URLs**.
- Repo-root example scripts and `readme.md` — app URLs only.

## Unchanged, deliberately

- The API base (`gapapi.karmahq.xyz`) — the API subdomain is not moving; see show-karma/gap-indexer#2372.
- `core/scripts/create-grant.ts` contact address — email is not moving until SPF/DKIM land on `.org`.
- **`core/class/contract/GapContract.ts` `name: "gap-attestation"`** — an EIP-712 namespace verified by deployed multicall contracts, not a hostname. A blanket find-and-replace would have broken on-chain verification.

## Not done here

No version bump and no npm publish — that is a deliberate human step. Existing consumers on the old version keep calling `.xyz` hosts, which is fine: those resolve permanently. Worth verifying the SDK's HTTP layer follows 308 and preserves method and body before relying on that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
